### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+dist: trusty
+sudo: required
+group: beta
+language: node_js
+node_js:
+  - "8"
+cache:
+  directories:
+    - node_modules
+before_install: npm install -g mocha
+install: npm install
+script:
+  - npm test


### PR DESCRIPTION
This change adds Travis continuous integration to the library.

Travis runs the Mocha tests upon building to check if tests pass before allowing merges.