### PR TITLE
[FIX] Bignum Error

### DIFF
--- a/client/statsdb.js
+++ b/client/statsdb.js
@@ -22,8 +22,11 @@ class StatsDB {
     accounts.forEach(async (account) => {
       const found = this.stats.find({ account })[0]
       if (found) {
-        found.bounties = new BigNumber(found.bounties)
-        found.costs = new BigNumber(found.costs)
+        const bounties = found.bounties ? found.bounties : 0
+        const costs = found.costs ? found.costs : 0
+
+        found.bounties = new BigNumber(bounties)
+        found.costs = new BigNumber(costs)
       } else {
         this.stats.insert({
           account,

--- a/client/statsdb.js
+++ b/client/statsdb.js
@@ -22,8 +22,8 @@ class StatsDB {
     accounts.forEach(async (account) => {
       const found = this.stats.find({ account })[0]
       if (found) {
-        const bounties = found.bounties ? found.bounties : 0
-        const costs = found.costs ? found.costs : 0
+        const bounties = found.bounties || 0
+        const costs = found.costs || 0
 
         found.bounties = new BigNumber(bounties)
         found.costs = new BigNumber(costs)


### PR DESCRIPTION
Fixes an error with handling bounties and costs.

This error happens because we transitioned to a new way of calculating ETH gain. Clearing (rebuilding) browser IndexedDB will remove the error, but this is a fix for backward compatibility.

![image](https://user-images.githubusercontent.com/9353642/40473731-4ac54506-5f3d-11e8-8fc2-dd10d201f416.png)
