### PR TITLE
Execution window length check

### DIFF
--- a/src/EconomicStrategy/IEconomicStrategy.ts
+++ b/src/EconomicStrategy/IEconomicStrategy.ts
@@ -29,4 +29,8 @@ export interface IEconomicStrategy {
    *      to subsidize gas costs to up to 30 gwei.
    */
   maxGasSubsidy?: number;
+
+  minExecutionWindow?: number;
+
+  minExecutionWindowBlock?: number;
 }

--- a/src/Enum/EconomicStrategyStatus.ts
+++ b/src/Enum/EconomicStrategyStatus.ts
@@ -2,5 +2,6 @@ export enum EconomicStrategyStatus {
   NOT_PROFITABLE = 'Transaction not profitable.',
   INSUFFICIENT_BALANCE = 'Not enough balance to claim.',
   CLAIM = 'Transaction can be claimed.',
-  DEPOSIT_TOO_HIGH = 'The transaction deposit is too high.'
+  DEPOSIT_TOO_HIGH = 'The transaction deposit is too high.',
+  WINDOW_TOO_SHORT = 'Execution window is too short'
 }

--- a/test/unit/UnitTestCacheScanner.ts
+++ b/test/unit/UnitTestCacheScanner.ts
@@ -1,0 +1,66 @@
+import * as TypeMoq from 'typemoq';
+import IRouter from '../../src/Router';
+import { Config } from '../../src';
+import CacheScanner from '../../src/Scanner/CacheScanner';
+import Cache, { ICachedTxDetails } from '../../src/Cache';
+import { TxStatus } from '../../src/Enum';
+import { ITxRequest } from '../../src/Types';
+import { assert } from 'chai';
+
+describe('Cache Scanner Unit Tests', () => {
+  it('does not route when cache empty', async () => {
+    const cache = TypeMoq.Mock.ofType<Cache<ICachedTxDetails>>();
+    cache.setup(c => c.isEmpty()).returns(() => true);
+
+    const router = TypeMoq.Mock.ofType<IRouter>();
+    const config = TypeMoq.Mock.ofType<Config>();
+    config.setup(c => c.cache).returns(() => cache.object);
+
+    const scanner = new CacheScanner(config.object, router.object);
+
+    await scanner.scanCache();
+
+    router.verify(r => r.route(TypeMoq.It.isAny()), TypeMoq.Times.never());
+  });
+
+  it('does prioritize requests in FreezePeriod ', async () => {
+    const tx1 = TypeMoq.Mock.ofType<ICachedTxDetails>();
+    tx1.setup(tx => tx.status).returns(() => TxStatus.FreezePeriod);
+
+    const tx2 = TypeMoq.Mock.ofType<ICachedTxDetails>();
+    tx2.setup(tx => tx.status).returns(() => TxStatus.Executed);
+
+    const tx3 = TypeMoq.Mock.ofType<ICachedTxDetails>();
+    tx3.setup(tx => tx.status).returns(() => TxStatus.ClaimWindow);
+
+    const cache = new Cache<ICachedTxDetails>();
+    cache.set('3', tx3.object);
+    cache.set('2', tx2.object);
+    cache.set('1', tx1.object);
+
+    const routed: ITxRequest[] = [];
+
+    const router = TypeMoq.Mock.ofType<IRouter>();
+    router.setup(r => r.route(TypeMoq.It.isAny())).callback(txRequest => routed.push(txRequest));
+
+    const eac = {
+      transactionRequest: (address: any) => {
+        const req = TypeMoq.Mock.ofType<ITxRequest>();
+        req.setup(r => r.address).returns(() => address);
+        return req.object;
+      }
+    };
+
+    const config = TypeMoq.Mock.ofType<Config>();
+    config.setup(c => c.cache).returns(() => cache);
+    config.setup(c => c.eac).returns(() => eac);
+
+    const scanner = new CacheScanner(config.object, router.object);
+
+    await scanner.scanCache();
+
+    router.verify(r => r.route(TypeMoq.It.isAny()), TypeMoq.Times.exactly(3));
+
+    assert.equal('1', routed.shift().address);
+  });
+});


### PR DESCRIPTION
It's possible to schedule contract with any values without validation. This feature adds the check for `reservedWindowSize` in claiming decision process. 

This should be default to 10 blocks or 150s and visible in CLI and DApp for users to set. 