### PR TITLE
Fix for bucket logic

### DIFF
--- a/src/Router/Router.ts
+++ b/src/Router/Router.ts
@@ -103,9 +103,6 @@ export default class Router implements IRouter {
         }
       } else {
         this.logger.info(`Claiming: Skipped - ${shouldClaimStatus}`, txRequest.address);
-        this.logger.debug(
-          `ECONOMIC STRATEGY: ${JSON.stringify(this.economicStrategyManager.strategy)}`
-        );
       }
     }
 

--- a/src/Scanner/Buckets.ts
+++ b/src/Scanner/Buckets.ts
@@ -2,27 +2,34 @@ import { WatchableBucket } from './WatchableBucket';
 import { IBuckets, IBucketPair } from '../Buckets';
 import { BucketWatchCallback } from './BucketWatchCallback';
 import { WatchableBucketFactory } from './WatchableBucketFactory';
+import { ILogger, DefaultLogger } from '../Logger';
 
 export class Buckets {
   private buckets: WatchableBucket[] = [];
   private watchableBucketFactory: WatchableBucketFactory;
+  private logger: ILogger;
 
-  constructor(watchableBucketFactory: WatchableBucketFactory) {
+  constructor(
+    watchableBucketFactory: WatchableBucketFactory,
+    logger: ILogger = new DefaultLogger()
+  ) {
     this.watchableBucketFactory = watchableBucketFactory;
+    this.logger = logger;
   }
 
   public async update(newBuckets: IBuckets, callback: BucketWatchCallback) {
     if (this.stopped) {
-      await this.addBucket(newBuckets.currentBuckets, callback);
-      await this.addBucket(newBuckets.nextBuckets, callback);
-      await this.addBucket(newBuckets.afterNextBuckets, callback);
+      await this.add(newBuckets, callback);
     } else {
       if (this.currentBucket.equals(newBuckets.currentBuckets)) {
         return;
+      } else if (this.nextBucket.equals(newBuckets.currentBuckets)) {
+        await this.shift();
+        await this.addBucket(newBuckets.afterNextBuckets, callback);
+      } else {
+        await this.stop();
+        await this.add(newBuckets, callback);
       }
-
-      await this.shift();
-      await this.addBucket(newBuckets.afterNextBuckets, callback);
     }
   }
 
@@ -32,19 +39,28 @@ export class Buckets {
     }
   }
 
+  private async add(newBuckets: IBuckets, callback: BucketWatchCallback) {
+    await this.addBucket(newBuckets.currentBuckets, callback);
+    await this.addBucket(newBuckets.nextBuckets, callback);
+    await this.addBucket(newBuckets.afterNextBuckets, callback);
+  }
+
   private async push(bucket: WatchableBucket) {
     await bucket.watch();
     this.buckets.push(bucket);
   }
 
   private async shift() {
+    this.logger.debug(`Buckets: Shifting currentBucket`);
     const bucket = this.buckets.shift();
+
     if (bucket) {
       await bucket.stop();
     }
   }
 
   private async addBucket(bucketPair: IBucketPair, callback: BucketWatchCallback) {
+    this.logger.debug(`Buckets: Adding new bucket ${JSON.stringify(bucketPair)}`);
     const bucket = await this.watchableBucketFactory.create(bucketPair, callback);
     await this.push(bucket);
   }
@@ -55,5 +71,9 @@ export class Buckets {
 
   private get currentBucket(): WatchableBucket {
     return this.buckets[0];
+  }
+
+  private get nextBucket(): WatchableBucket {
+    return this.buckets[1];
   }
 }

--- a/src/Scanner/ChainScanner.ts
+++ b/src/Scanner/ChainScanner.ts
@@ -21,7 +21,10 @@ export default class ChainScanner extends CacheScanner {
     super(config, router);
     this.requestFactory = config.eac.requestFactory();
     this.bucketCalc = new BucketCalc(config.util, this.requestFactory);
-    this.buckets = new Buckets(new WatchableBucketFactory(this.requestFactory, this.config.logger));
+    this.buckets = new Buckets(
+      new WatchableBucketFactory(this.requestFactory, this.config.logger),
+      this.config.logger
+    );
 
     this.handleRequest = this.handleRequest.bind(this);
   }

--- a/src/Scanner/WatchableBucket.ts
+++ b/src/Scanner/WatchableBucket.ts
@@ -35,6 +35,9 @@ export class WatchableBucket {
   }
 
   public equals(newBucket: IBucketPair): boolean {
+    this.logger.debug(
+      `Buckets: comparing ${JSON.stringify(this.bucket)} to ${JSON.stringify(newBucket)}`
+    );
     return (
       newBucket.blockBucket === this.bucket.blockBucket &&
       newBucket.timestampBucket === this.bucket.timestampBucket

--- a/test/unit/UnitTestWatchableBucket.ts
+++ b/test/unit/UnitTestWatchableBucket.ts
@@ -1,6 +1,7 @@
 import * as TypeMoq from 'typemoq';
 import { IBucketWatcher } from '../../src/Scanner/IBucketWatcher';
 import { WatchableBucket } from '../../src/Scanner/WatchableBucket';
+import { assert } from 'chai';
 
 describe('WatchableBucket', () => {
   it('should not stop previous watch when there was not any started', async () => {
@@ -64,5 +65,28 @@ describe('WatchableBucket', () => {
     await watchableBucket.stop();
 
     requestFactoryMock.verifyAll();
+  });
+
+  it('should compare', async () => {
+    const bucketPair = {
+      timestampBucket: 100,
+      blockBucket: 102
+    };
+
+    const differentBucket = {
+      timestampBucket: 101,
+      blockBucket: 102
+    };
+
+    const differentBucket2 = {
+      timestampBucket: 100,
+      blockBucket: 101
+    };
+
+    const watchableBucket = new WatchableBucket(bucketPair, null, null);
+
+    assert.isTrue(watchableBucket.equals(bucketPair));
+    assert.isFalse(watchableBucket.equals(differentBucket));
+    assert.isFalse(watchableBucket.equals(differentBucket2));
   });
 });


### PR DESCRIPTION
This is the fix for #310 that wrongly assumed that `timeBucket` and `blockBucket` changes together 🤦‍♂️ 

* shift only when middle is the same as new current (so it's safe to shift)
* restart all if any change has been detected
* more tests
* more logs