### PR TITLE
Errored transactions returns receipts - revert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 cache:
   directories:
     - node_modules
-before_install: npm install -g truffle
+before_install: npm install -g truffle@4.1.15
 install: npm install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_script:
 script:
   - npx eac-deploy-contracts
   - npm run build
-  - npm run test:e2e
   - npm run test:coverage
+  - npm run test:e2e
 
 after_success:
   - npm run report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 cache:
   directories:
     - node_modules
-before_install: npm install -g truffle@4.1.15
+before_install: npm install -g truffle@4.1.14
 install: npm install
 
 before_script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -477,6 +477,18 @@
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.37",
             "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "requires": {
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-shh": {
@@ -667,7 +679,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -1036,12 +1048,12 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -1409,7 +1421,7 @@
     },
     "babelify": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "requires": {
         "babel-core": "^6.0.14",
@@ -1642,7 +1654,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -1676,7 +1688,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -1827,7 +1839,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -1862,7 +1874,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -2146,7 +2158,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -2163,7 +2175,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -2175,7 +2187,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -2197,7 +2209,7 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
         }
       }
@@ -2503,7 +2515,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -3268,7 +3280,7 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
@@ -4404,7 +4416,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -4764,7 +4776,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -5077,7 +5089,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -5178,7 +5190,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5215,7 +5227,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5886,7 +5898,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
@@ -5912,7 +5924,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -5947,7 +5959,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -6170,7 +6182,7 @@
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
@@ -7608,7 +7620,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -7669,7 +7681,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
         "asn1.js": "^4.0.0",
@@ -8043,7 +8055,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -8303,7 +8315,7 @@
     },
     "scrypt-js": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
       "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
     },
     "scrypt.js": {
@@ -8462,7 +8474,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -8676,7 +8688,7 @@
         },
         "yargs": {
           "version": "4.8.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "requires": {
             "cliui": "^3.2.0",
@@ -8982,7 +8994,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -9025,7 +9037,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         }
       }
@@ -9048,7 +9060,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -9221,7 +9233,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -9413,7 +9425,7 @@
         },
         "buffer": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "requires": {
             "base64-js": "0.0.8",
@@ -9628,13 +9640,13 @@
         },
         "utf8": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
           "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
           "dev": true
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
           "dev": true
         },
@@ -10111,7 +10123,7 @@
         },
         "utf8": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
           "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
         },
         "web3-core": {
@@ -10456,7 +10468,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
@@ -10480,7 +10492,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -10574,7 +10586,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",

--- a/src/Actions/Actions.ts
+++ b/src/Actions/Actions.ts
@@ -72,10 +72,10 @@ export default class Actions implements IActions {
       return TxSendStatus.STATUS(TxSendStatus.SUCCESS, context);
     } else if (status === TxSendStatus.UNKNOWN_ERROR) {
       this.logger.error(status);
+      return TxSendStatus.STATUS(TxSendStatus.FAIL, context);
     } else {
       return TxSendStatus.STATUS(status, context);
     }
-    return TxSendStatus.STATUS(TxSendStatus.FAIL, context);
   }
 
   public async execute(txRequest: ITransactionRequest, gasPrice: BigNumber): Promise<TxSendStatus> {

--- a/src/Enum/TxSendStatus.ts
+++ b/src/Enum/TxSendStatus.ts
@@ -9,7 +9,7 @@ export enum TxSendStatus {
 
   BUSY = 'Sending transaction is already in progress. Please wait for account to complete tx.',
   PROGRESS = 'Transaction in progress',
-  MINED = 'Transaction minded in uncle block',
+  MINED_IN_UNCLE = 'Transaction mined in uncle block',
   FAIL = 'FAILED',
   PENDING = 'PENDING',
 
@@ -29,7 +29,7 @@ export enum TxSendStatus {
 export namespace TxSendStatus {
   export function STATUS(msg: TxSendStatus, context: TxSendStatus) {
     switch (msg) {
-      case 'SUCCESS':
+      case TxSendStatus.SUCCESS:
         switch (context) {
           case TxSendStatus.claim:
             this.TYPE_VARIABLE = 'Claiming: Success';
@@ -39,7 +39,7 @@ export namespace TxSendStatus {
             break;
         }
         break;
-      case 'Sending transaction is already in progress. Please wait for account to complete tx.':
+      case TxSendStatus.BUSY:
         switch (context) {
           case TxSendStatus.claim:
             this.TYPE_VARIABLE = 'Claiming: Skipped - Account is busy';
@@ -49,7 +49,7 @@ export namespace TxSendStatus {
             break;
         }
         break;
-      case 'Transaction in progress':
+      case TxSendStatus.PROGRESS:
         switch (context) {
           case TxSendStatus.claim:
             this.TYPE_VARIABLE = 'Claiming: Skipped - In progress';
@@ -59,7 +59,7 @@ export namespace TxSendStatus {
             break;
         }
         break;
-      case 'PENDING':
+      case TxSendStatus.PENDING:
         switch (context) {
           case TxSendStatus.claim:
             this.TYPE_VARIABLE = 'Claiming: Skipped - Other claiming found';
@@ -69,7 +69,7 @@ export namespace TxSendStatus {
             break;
         }
         break;
-      case 'FAILED':
+      case TxSendStatus.FAIL:
         switch (context) {
           case TxSendStatus.claim:
             this.TYPE_VARIABLE = 'Claiming: Transaction already claimed';
@@ -79,7 +79,7 @@ export namespace TxSendStatus {
             break;
         }
         break;
-      case 'Transaction minded in uncle block':
+      case TxSendStatus.MINED_IN_UNCLE:
         switch (context) {
           case TxSendStatus.claim:
             this.TYPE_VARIABLE = 'Claiming: Transaction mined in uncle block';

--- a/src/Router/Router.ts
+++ b/src/Router/Router.ts
@@ -256,8 +256,8 @@ export default class Router implements IRouter {
       case TxSendStatus.STATUS(TxSendStatus.PENDING, TxSendStatus.claim):
       case TxSendStatus.STATUS(TxSendStatus.BUSY, TxSendStatus.execute):
       case TxSendStatus.STATUS(TxSendStatus.PENDING, TxSendStatus.execute):
-      case TxSendStatus.STATUS(TxSendStatus.MINED, TxSendStatus.execute):
-      case TxSendStatus.STATUS(TxSendStatus.MINED, TxSendStatus.claim):
+      case TxSendStatus.STATUS(TxSendStatus.MINED_IN_UNCLE, TxSendStatus.execute):
+      case TxSendStatus.STATUS(TxSendStatus.MINED_IN_UNCLE, TxSendStatus.claim):
         this.logger.info(status, txRequest.address);
         break;
       case TxSendStatus.STATUS(TxSendStatus.FAIL, TxSendStatus.claim):

--- a/src/Wallet/TransactionReceiptAwaiter.ts
+++ b/src/Wallet/TransactionReceiptAwaiter.ts
@@ -1,0 +1,84 @@
+import { TransactionReceipt } from 'web3/types';
+import { Util } from '@ethereum-alarm-clock/lib';
+
+const POLL_INTERVAL = 3000;
+
+export interface ITransactionReceiptAwaiter {
+  waitForConfirmations(hash: string, blocks: number): Promise<TransactionReceipt>;
+}
+
+export class TransactionReceiptAwaiter implements ITransactionReceiptAwaiter {
+  private util: Util;
+
+  public constructor(util: Util) {
+    this.util = util;
+  }
+
+  public async waitForConfirmations(
+    hash: string,
+    blocks: number = 12
+  ): Promise<TransactionReceipt> {
+    return this.awaitTx(hash, {
+      ensureNotUncle: true,
+      interval: POLL_INTERVAL,
+      blocks
+    });
+  }
+
+  // tslint:disable-next-line:cognitive-complexity
+  private awaitTx(hash: string, options: any): Promise<TransactionReceipt> {
+    const interval = options && options.interval ? options.interval : 500;
+    const transactionReceiptAsync = async (txnHash: string, resolve: any, reject: any) => {
+      try {
+        const receipt = this.util.getReceipt(txnHash);
+        if (!receipt) {
+          setTimeout(() => {
+            transactionReceiptAsync(txnHash, resolve, reject);
+          }, interval);
+        } else {
+          if (options && options.ensureNotUncle) {
+            const resolvedReceipt = await receipt;
+            if (!resolvedReceipt || !resolvedReceipt.blockNumber) {
+              setTimeout(() => {
+                transactionReceiptAsync(txnHash, resolve, reject);
+              }, interval);
+            } else {
+              try {
+                const block = await this.util.getBlock(resolvedReceipt.blockNumber);
+                const current = await this.util.getBlock('latest');
+                if (current.number - block.number >= options.blocks) {
+                  const txn = await this.util.getTransaction(txnHash);
+                  if (txn.blockNumber != null) {
+                    resolve(resolvedReceipt);
+                  } else {
+                    reject(
+                      new Error(
+                        'Transaction with hash: ' + txnHash + ' ended up in an uncle block.'
+                      )
+                    );
+                  }
+                } else {
+                  setTimeout(() => {
+                    transactionReceiptAsync(txnHash, resolve, reject);
+                  }, interval);
+                }
+              } catch (e) {
+                setTimeout(() => {
+                  transactionReceiptAsync(txnHash, resolve, reject);
+                }, interval);
+              }
+            }
+          } else {
+            resolve(receipt);
+          }
+        }
+      } catch (e) {
+        reject(e);
+      }
+    };
+
+    return new Promise((resolve, reject) => {
+      transactionReceiptAsync(hash, resolve, reject);
+    });
+  }
+}

--- a/src/Wallet/Wallet.ts
+++ b/src/Wallet/Wallet.ts
@@ -211,7 +211,7 @@ export class Wallet {
       this.accountState.set(from, opts.to, opts.operation, TransactionState.ERROR);
       return {
         from,
-        status: TxSendStatus.MINED
+        status: TxSendStatus.MINED_IN_UNCLE
       };
     }
 

--- a/src/Wallet/Wallet.ts
+++ b/src/Wallet/Wallet.ts
@@ -200,10 +200,7 @@ export class Wallet {
     try {
       this.logger.debug(`Awaiting for confirmation for tx ${hash} from ${from}`, opts.to);
 
-      receipt = await await this.transactionAwaiter.waitForConfirmations(
-        hash,
-        this.CONFIRMATION_BLOCKS
-      );
+      receipt = await this.transactionAwaiter.waitForConfirmations(hash, this.CONFIRMATION_BLOCKS);
       this.accountState.set(from, opts.to, opts.operation, TransactionState.CONFIRMED);
 
       this.logger.debug(`Transaction ${hash} from ${from} confirmed`, opts.to);

--- a/test/e2e/TestScheduleTx.ts
+++ b/test/e2e/TestScheduleTx.ts
@@ -1,45 +1,10 @@
-import { EAC, Util } from '@ethereum-alarm-clock/lib';
-import BigNumber from 'bignumber.js';
+import { Util } from '@ethereum-alarm-clock/lib';
 import { expect } from 'chai';
 import { providerUrl } from '../helpers';
 import { getHelperMethods } from '../helpers/Helpers';
+import { scheduleTestTx } from '../helpers/scheduleTestTx';
 
 const web3 = Util.getWeb3FromProviderUrl(providerUrl);
-
-export const SCHEDULED_TX_PARAMS = {
-  callValue: new BigNumber(Math.pow(10, 18))
-};
-
-export const scheduleTestTx = async (blocksInFuture = 270) => {
-  const eac = new EAC(web3);
-
-  const { callValue } = SCHEDULED_TX_PARAMS;
-
-  const callGas = new BigNumber(1000000);
-  const gasPrice = new BigNumber(web3.utils.toWei('20', 'gwei'));
-  const fee = new BigNumber(0);
-  const bounty = new BigNumber(web3.utils.toWei('0.1', 'ether'));
-
-  const accounts = await web3.eth.getAccounts();
-  const mainAccount = accounts[0];
-
-  const receipt = await eac.schedule({
-    from: mainAccount,
-    toAddress: mainAccount,
-    callGas,
-    callData: '',
-    callValue,
-    windowSize: new BigNumber(30),
-    windowStart: new BigNumber((await web3.eth.getBlockNumber()) + blocksInFuture),
-    gasPrice,
-    fee,
-    bounty,
-    requiredDeposit: new BigNumber('0'),
-    timestampScheduling: false
-  });
-
-  return eac.getTxRequestFromReceipt(receipt);
-};
 
 if (process.env.RUN_ONLY_OPTIONAL_TESTS !== 'true') {
   describe('ScheduleTx', () => {

--- a/test/e2e/TestTimeNode.ts
+++ b/test/e2e/TestTimeNode.ts
@@ -1,10 +1,11 @@
-import { assert, expect } from 'chai';
-import { TimeNode, Config } from '../../src/index';
-import { mockConfig } from '../helpers';
-import { scheduleTestTx } from './TestScheduleTx';
-import { getHelperMethods } from '../helpers/Helpers';
 import { EAC } from '@ethereum-alarm-clock/lib';
+import { assert, expect } from 'chai';
 import Web3 = require('web3');
+
+import { Config, TimeNode } from '../../src';
+import { mockConfig } from '../helpers';
+import { getHelperMethods } from '../helpers/Helpers';
+import { scheduleTestTx } from '../helpers/scheduleTestTx';
 
 const TIMENODE_ADDRESS = '0x487a54e1d033db51c8ee8c03edac2a0f8a6892c6';
 

--- a/test/helpers/scheduleTestTx.ts
+++ b/test/helpers/scheduleTestTx.ts
@@ -1,0 +1,40 @@
+import { EAC, Util } from '@ethereum-alarm-clock/lib';
+import BigNumber from 'bignumber.js';
+import { providerUrl } from '../helpers';
+
+const web3 = Util.getWeb3FromProviderUrl(providerUrl);
+
+export const SCHEDULED_TX_PARAMS = {
+  callValue: new BigNumber(Math.pow(10, 18))
+};
+
+export const scheduleTestTx = async (blocksInFuture = 270) => {
+  const eac = new EAC(web3);
+
+  const { callValue } = SCHEDULED_TX_PARAMS;
+
+  const callGas = new BigNumber(1000000);
+  const gasPrice = new BigNumber(web3.utils.toWei('20', 'gwei'));
+  const fee = new BigNumber(0);
+  const bounty = new BigNumber(web3.utils.toWei('0.1', 'ether'));
+
+  const accounts = await web3.eth.getAccounts();
+  const mainAccount = accounts[0];
+
+  const receipt = await eac.schedule({
+    from: mainAccount,
+    toAddress: mainAccount,
+    callGas,
+    callData: '',
+    callValue,
+    windowSize: new BigNumber(30),
+    windowStart: new BigNumber((await web3.eth.getBlockNumber()) + blocksInFuture),
+    gasPrice,
+    fee,
+    bounty,
+    requiredDeposit: new BigNumber('0'),
+    timestampScheduling: false
+  });
+
+  return eac.getTxRequestFromReceipt(receipt);
+};

--- a/test/unit/UnitTestWallet.ts
+++ b/test/unit/UnitTestWallet.ts
@@ -272,7 +272,7 @@ describe('Wallet Unit Tests', () => {
 
     await fundWallet(address);
 
-    const scheduledTxAddress = await scheduleTestTx(200);
+    const scheduledTxAddress = await scheduleTestTx(255);
     const txRequest = config.eac.transactionRequest(scheduledTxAddress);
 
     await txRequest.fillData();
@@ -299,7 +299,7 @@ describe('Wallet Unit Tests', () => {
 
     await fundWallet(address);
 
-    const scheduledTxAddress = await scheduleTestTx(200);
+    const scheduledTxAddress = await scheduleTestTx(255);
     const txRequest = config.eac.transactionRequest(scheduledTxAddress);
 
     await txRequest.fillData();

--- a/test/unit/UnitTestWallet.ts
+++ b/test/unit/UnitTestWallet.ts
@@ -273,6 +273,7 @@ describe('Wallet Unit Tests', () => {
     await fundWallet(address);
 
     const scheduledTxAddress = await scheduleTestTx(255);
+    console.log(`-------------------- Deployed transaction ADDRESS: ` + scheduledTxAddress);
     const txRequest = config.eac.transactionRequest(scheduledTxAddress);
 
     await txRequest.fillData();
@@ -300,6 +301,7 @@ describe('Wallet Unit Tests', () => {
     await fundWallet(address);
 
     const scheduledTxAddress = await scheduleTestTx(255);
+    console.log(`-------------------- Deployed transaction ADDRESS: ` + scheduledTxAddress);
     const txRequest = config.eac.transactionRequest(scheduledTxAddress);
 
     await txRequest.fillData();

--- a/test/unit/UnitTestWallet.ts
+++ b/test/unit/UnitTestWallet.ts
@@ -9,6 +9,7 @@ import { AccountState, TransactionState } from '../../src/Wallet/AccountState';
 import { Operation } from '../../src/Types/Operation';
 import ITransactionOptions from '../../src/Types/ITransactionOptions';
 import { IWalletReceipt } from '../../src/Wallet';
+import { scheduleTestTx } from '../helpers/scheduleTestTx';
 
 const PRIVATE_KEY = 'fdf2e15fd858d9d81e31baa1fe76de9c7d49af0018a1322aa2b9e493b02afa26';
 
@@ -27,7 +28,7 @@ const fundWallet = async (address: string) => {
       {
         from: myAccount,
         to: address,
-        value: config.web3.utils.toWei('0.5', 'ether')
+        value: config.web3.utils.toWei('0.1', 'ether')
       },
       () => setTimeout(resolve, 1000)
     );
@@ -45,7 +46,7 @@ const reset = async () => {
     to: myAccount,
     gas: new BigNumber('150000'),
     gasPrice: new BigNumber(config.web3.utils.toWei('21', 'gwei')),
-    value: new BigNumber(config.web3.utils.toWei('0.1', 'ether')),
+    value: new BigNumber(config.web3.utils.toWei('0.01', 'ether')),
     operation: Operation.CLAIM,
     data: ''
   };
@@ -262,6 +263,63 @@ describe('Wallet Unit Tests', () => {
       assert.property(receipt, 'receipt');
     }).timeout(10000);
   });
+
+  it('returns receipt after successful claim', async () => {
+    wallet.create(1);
+
+    const idx = 0;
+    const address = wallet.getAddresses()[idx];
+
+    await fundWallet(address);
+
+    const scheduledTxAddress = await scheduleTestTx();
+    const txRequest = config.eac.transactionRequest(scheduledTxAddress);
+
+    await txRequest.fillData();
+
+    opts = {
+      to: scheduledTxAddress,
+      gas: new BigNumber('150000'),
+      gasPrice: new BigNumber(config.web3.utils.toWei('1', 'gwei')),
+      value: new BigNumber(0),
+      operation: Operation.CLAIM,
+      data: txRequest.claimData
+    };
+
+    const receipt = await wallet.sendFromNext(opts);
+
+    assert.equal(TxSendStatus.OK, receipt.status);
+  }).timeout(10000);
+
+  it('returns receipt after already claimed error', async () => {
+    wallet.create(1);
+
+    const idx = 0;
+    const address = wallet.getAddresses()[idx];
+
+    await fundWallet(address);
+
+    const scheduledTxAddress = await scheduleTestTx();
+    const txRequest = config.eac.transactionRequest(scheduledTxAddress);
+
+    await txRequest.fillData();
+
+    opts = {
+      to: scheduledTxAddress,
+      gas: new BigNumber('150000'),
+      gasPrice: new BigNumber(config.web3.utils.toWei('1', 'gwei')),
+      value: new BigNumber(0),
+      operation: Operation.CLAIM,
+      data: txRequest.claimData
+    };
+
+    await wallet.sendFromNext(opts);
+
+    const receipt = await wallet.sendFromNext(opts);
+
+    assert.equal(TxSendStatus.FAIL, receipt.status);
+    assert.exists(receipt.receipt);
+  }).timeout(10000);
 
   describe('sendFromNext()', () => {
     it('generates the next index and sends from it', async () => {

--- a/test/unit/UnitTestWallet.ts
+++ b/test/unit/UnitTestWallet.ts
@@ -237,7 +237,7 @@ describe('Wallet Unit Tests', () => {
       receipt = await wallet.sendFromIndex(idx, opts);
 
       assert.isTrue(isTransactionStatusSuccessful(receipt.receipt.status));
-    }).timeout(10000);
+    }).timeout(25000);
 
     it('returns receipt when is able to send the transaction', async () => {
       wallet.create(1);
@@ -261,7 +261,7 @@ describe('Wallet Unit Tests', () => {
 
       assert.property(receipt, 'from');
       assert.property(receipt, 'receipt');
-    }).timeout(10000);
+    }).timeout(15000);
   });
 
   it('returns receipt after successful claim', async () => {
@@ -272,7 +272,7 @@ describe('Wallet Unit Tests', () => {
 
     await fundWallet(address);
 
-    const scheduledTxAddress = await scheduleTestTx();
+    const scheduledTxAddress = await scheduleTestTx(200);
     const txRequest = config.eac.transactionRequest(scheduledTxAddress);
 
     await txRequest.fillData();
@@ -289,7 +289,7 @@ describe('Wallet Unit Tests', () => {
     const receipt = await wallet.sendFromNext(opts);
 
     assert.equal(TxSendStatus.OK, receipt.status);
-  }).timeout(10000);
+  }).timeout(15000);
 
   it('returns receipt after already claimed error', async () => {
     wallet.create(1);
@@ -299,7 +299,7 @@ describe('Wallet Unit Tests', () => {
 
     await fundWallet(address);
 
-    const scheduledTxAddress = await scheduleTestTx();
+    const scheduledTxAddress = await scheduleTestTx(200);
     const txRequest = config.eac.transactionRequest(scheduledTxAddress);
 
     await txRequest.fillData();
@@ -319,7 +319,7 @@ describe('Wallet Unit Tests', () => {
 
     assert.equal(TxSendStatus.FAIL, receipt.status);
     assert.exists(receipt.receipt);
-  }).timeout(10000);
+  }).timeout(25000);
 
   describe('sendFromNext()', () => {
     it('generates the next index and sends from it', async () => {


### PR DESCRIPTION
After migration to web3 1.0 and use of internal transaction await it turns out that errored messages do not return the receipts. This is important for accounting functionality so for e.g error CLAIM transactions got accounted for properly.

The fix reverts partially the changes to `wallet.ts` file before the #343 